### PR TITLE
Add test and Docker build workflow

### DIFF
--- a/.github/workflows/tests-and-docker.yml
+++ b/.github/workflows/tests-and-docker.yml
@@ -1,0 +1,45 @@
+name: Tests and Docker
+
+on:
+  push:
+  pull_request:
+
+env:
+  rust_version: "1.82.0"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y aptitude
+          sudo aptitude install -y libgstrtspserver-1.0-dev libgstreamer1.0-dev libgtk2.0-dev protobuf-compiler libssl-dev
+      - name: Install Rust
+        run: rustup default "${{ env.rust_version }}"
+      - name: Run tests
+        run: cargo test --workspace --all-features
+
+  docker:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+        env:
+          DOCKER_BUILDKIT: 1


### PR DESCRIPTION
## Summary
- run Rust tests on pushes and PRs
- build and push Docker image to ghcr.io after tests succeed on main branch

## Testing
- `pre-commit run --files .github/workflows/tests-and-docker.yml`
- `cargo test --workspace --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a1e5049f808332b5590158d6a0bb28